### PR TITLE
Adding requirements.txt and some extensions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@
 + it is set to the BIMTester included IFC2x3 example and the German feature file
 + click on run
 + :-)
+
+### Running CLI without FreeCad or BlenderBIM
+
++ Clone the repository
++ Create new python environment (e.g., Conda or venv)
++ Run `pip install -r requirements.txt` in console. 
+  Make sure your console is set to the correct path (e.g., `path/to/bimtesterfc` folder)
++ Run CLI tool (e.g.,  ` python .\code_bimtester\cli.py -i .\code_bimtester\examples\01_ifcschema_translated\IFC2X3_col.ifc -f .\code_bimtester\examples\01_ifcschema_translated\features\de_grundlagen.feature -c`)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pystache
+python-ifcopenshell
+behave


### PR DESCRIPTION
I have extended the repository with a requirements.txt file to install all required packages with a single command. The IfcOpenShell library is available via PyPI. 
I have tested with Python 3.9 but ran into issues when testing a Python 3.10 environment. This is likely an issue on the ifcopenshell wheel. 

[Link to IfcOpenShell wheel](https://pypi.org/project/python-ifcopenshell/)
